### PR TITLE
Update comment on class ClockworkPath referring to pathToOrigin funciton

### DIFF
--- a/src/wrappers/path.ts
+++ b/src/wrappers/path.ts
@@ -3,7 +3,7 @@ import { Path } from '../wasm/screeps_clockwork';
 
 /**
  * A path from a start position to an end position. Typically returned by a
- * function like `pathToFlowFieldOrigin` rather than created directly.
+ * function like `ClockworkMultiroomFlowField.pathToOrigin` rather than created directly.
  */
 export class ClockworkPath {
   constructor(private readonly path: Path) {}


### PR DESCRIPTION
My initial efforts to follow the code in this repo were stymied by this comment leading to a dead end. Hopefully this change helps someone else avoid that trap.