### PR TITLE
Resolve build warnings

### DIFF
--- a/lib/datatypes/distance_map.rs
+++ b/lib/datatypes/distance_map.rs
@@ -102,7 +102,7 @@ impl<'a> Iterator for DistanceMapEnumerate<'a> {
 
 impl DistanceMap {
     /// Returns an iterator that yields (RoomXY, &T) pairs
-    pub fn enumerate(&self) -> DistanceMapEnumerate {
+    pub fn enumerate(&'_ self) -> DistanceMapEnumerate<'_> {
         DistanceMapEnumerate {
             tile_map: self,
             current_index: 0,

--- a/lib/helpers/profiler.rs
+++ b/lib/helpers/profiler.rs
@@ -198,9 +198,7 @@ impl Profiler {
             ));
         }
 
-        unsafe {
-            log(&table);
-        }
+        log(&table);
     }
 
     pub fn reset(&self) {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod algorithms;
 mod datatypes;
 mod helpers;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="../types.d.ts" />
 import 'fastestsmallesttextencoderdecoder-encodeinto/EncoderDecoderTogether.min.js';
 
 import {


### PR DESCRIPTION
When I `npm run build` I encounter a variety of warnings, summarized here:
```
warning: unnecessary `unsafe` block
   --> lib/helpers/profiler.rs:201:9
warning: constant `MAX_PROFILED_FUNCTIONS` is never used
 --> lib/helpers/profiler.rs:8:7
warning: struct `ProfileEntry` is never constructed
  --> lib/helpers/profiler.rs:15:8
warning: struct `Profiler` is never constructed
  --> lib/helpers/profiler.rs:33:12
warning: multiple associated items are never used
   --> lib/helpers/profiler.rs:44:12
warning: struct `ProfileStats` is never constructed
   --> lib/helpers/profiler.rs:219:12
warning: hiding a lifetime that's elided elsewhere is confusing
   --> lib/datatypes/distance_map.rs:105:22
```

```
src/index.ts → dist/index.js...
(!) Plugin typescript: @rollup/plugin-typescript TS2339: Property '__packedPos' does not exist on type 'RoomPosition'.
test/main.ts → dist_test/main.js...
(!) Plugin typescript: @rollup/plugin-typescript TS2339: Property '__packedPos' does not exist on type 'RoomPosition'.
```

This PR resolves these warnings by removing the unnecessary unsafe block, allowing dead code crate-wide, modifying the problematic lifetime hiding, and explicitly referencing the types where rollup's typescript plugin can see them.

My environment:
```
% rustc --version
rustc 1.94.0-nightly (c61a3a44d 2025-12-09)
% cargo --version
cargo 1.94.0-nightly (2c283a9a5 2025-12-04)
% node --version
v24.12.0
% npm list
screeps-clockwork@0.7.1 /home/sparr/src/games/Screeps/screeps-clockwork
├── @rollup/plugin-commonjs@28.0.6
├── @rollup/plugin-node-resolve@16.0.1
├── @rollup/plugin-typescript@12.1.3
├── @rollup/plugin-wasm@6.2.2
├── @types/node@24.0.12
├── @types/screeps@3.3.8
├── @typescript-eslint/eslint-plugin@8.36.0
├── @typescript-eslint/parser@8.36.0
├── eslint@9.30.1
├── fastestsmallesttextencoderdecoder-encodeinto@1.0.22
├── node-gyp-build@4.8.4 extraneous
├── npm-run-all@4.1.5
├── prettier@3.6.0
├── rollup-plugin-clear@2.0.7
├── rollup-plugin-copy@3.5.0
├── rollup-plugin-screeps@1.0.1
├── rollup@2.79.2
├── source-map@0.6.1
├── tslib@2.8.1
├── typedoc@0.28.5
└── typescript@5.7.3
```