### PR TITLE
Add diagonal/orthogonal and straight/zigzag preferences for paths

### DIFF
--- a/lib/algorithms/map/mod.rs
+++ b/lib/algorithms/map/mod.rs
@@ -51,6 +51,25 @@ pub fn neighbors_without_edges(position: Position) -> impl Iterator<Item = Posit
         .filter_map(move |dir| position.checked_add_direction(*dir).ok())
 }
 
+/// Adjacency in Screeps is not perfectly euclidean: we need to apply
+/// special rules at room edges.
+pub fn neighbors_directions(position: Position) -> impl Iterator<Item = (Position,Direction)> {
+    PREFERRED_DIRECTIONS
+        .iter()
+        .map(move |dir| (position.checked_add_direction(*dir),*dir))
+        .filter(|tuple| tuple.0.ok().is_some())
+        .map(|tuple| (corresponding_room_edge(tuple.0.unwrap()),tuple.1))
+}
+/// Adjacency in Screeps is not perfectly euclidean: we need to apply
+/// special rules at room edges.
+pub fn neighbors_directions_without_edges(position: Position) -> impl Iterator<Item = (Position,Direction)> {
+    PREFERRED_DIRECTIONS
+        .iter()
+        .map(move |dir| (position.checked_add_direction(*dir),*dir))
+        .filter(|tuple| tuple.0.ok().is_some())
+        .map(|tuple| (tuple.0.unwrap(),tuple.1))
+}
+
 lazy_static! {
     static ref DIRECTION_LOOKUP: [Vec<Direction>; 9] = [
         // Any direction

--- a/lib/algorithms/path/mod.rs
+++ b/lib/algorithms/path/mod.rs
@@ -1,3 +1,4 @@
+pub mod preference;
 pub mod to_multiroom_distance_map_origin;
 pub mod to_multiroom_flow_field_origin;
 pub mod to_multiroom_mono_flow_field_origin;

--- a/lib/algorithms/path/preference.rs
+++ b/lib/algorithms/path/preference.rs
@@ -1,0 +1,19 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Default,PartialEq)]
+pub enum PathPreferenceGonality {
+    #[default]
+    None,
+    Orthogonal,
+    Diagonal
+}
+
+#[wasm_bindgen]
+#[derive(Default,PartialEq)]
+pub enum PathPreferenceTurns {
+    #[default]
+    None,
+    Straight,
+    Zigzag
+}

--- a/lib/algorithms/path/to_multiroom_distance_map_origin.rs
+++ b/lib/algorithms/path/to_multiroom_distance_map_origin.rs
@@ -1,5 +1,8 @@
 use crate::algorithms::map::corresponding_room_edge;
+use crate::algorithms::map::neighbors_directions_without_edges;
 use crate::algorithms::map::neighbors_without_edges;
+use crate::algorithms::path::preference::PathPreferenceGonality;
+use crate::algorithms::path::preference::PathPreferenceTurns;
 use crate::datatypes::MultiroomDistanceMap;
 use crate::datatypes::Path;
 use crate::log;
@@ -14,6 +17,8 @@ const MAX_STEPS: usize = 2500;
 pub fn path_to_multiroom_distance_map_origin(
     start: Position,
     distance_map: &MultiroomDistanceMap,
+    prefer_diagonal: PathPreferenceGonality,
+    prefer_turns: PathPreferenceTurns
 ) -> Result<Path, &'static str> {
     let mut path = Path::new();
     let mut visited = HashSet::new();
@@ -33,12 +38,40 @@ pub fn path_to_multiroom_distance_map_origin(
         let mut next_pos = None;
         let mut min_distance = usize::MAX;
 
-        for neighbor in neighbors_without_edges(current) {
-            let neighbor_distance = distance_map.get(neighbor);
+        if prefer_diagonal != PathPreferenceGonality::None || prefer_turns != PathPreferenceTurns::None {
+            let mut prev_direction = None;
+            for (neighbor, direction) in neighbors_directions_without_edges(current) {
+                let neighbor_distance = distance_map.get(neighbor);
 
-            if neighbor_distance < min_distance {
-                min_distance = neighbor_distance;
-                next_pos = Some(neighbor);
+                let mut better = false;
+                if neighbor_distance < min_distance {
+                    better = true;
+                } else if neighbor_distance == min_distance {
+                    if prefer_turns != PathPreferenceTurns::None {
+                        if (prefer_turns == PathPreferenceTurns::Straight) == (match prev_direction {None=>false,Some(prev_direction)=>direction == prev_direction}) {
+                            better = true;
+                        }
+                        if !better && prefer_diagonal != PathPreferenceGonality::None {
+                            if (prefer_diagonal == PathPreferenceGonality::Diagonal) == direction.is_diagonal() {
+                                better = true;
+                            }
+                        }
+                    }
+                }
+                if better {
+                    min_distance = neighbor_distance;
+                    next_pos = Some(neighbor);
+                }
+                prev_direction = Some(direction);
+            }
+        } else {
+            for neighbor in neighbors_without_edges(current) {
+                let neighbor_distance = distance_map.get(neighbor);
+
+                if neighbor_distance < min_distance {
+                    min_distance = neighbor_distance;
+                    next_pos = Some(neighbor);
+                }
             }
         }
 
@@ -70,8 +103,10 @@ pub fn path_to_multiroom_distance_map_origin(
 pub fn js_path_to_multiroom_distance_map_origin(
     start: u32,
     distance_map: &MultiroomDistanceMap,
+    prefer_diagonal: PathPreferenceGonality,
+    prefer_turns: PathPreferenceTurns
 ) -> Path {
-    match path_to_multiroom_distance_map_origin(Position::from_packed(start), distance_map) {
+    match path_to_multiroom_distance_map_origin(Position::from_packed(start), distance_map, prefer_diagonal, prefer_turns) {
         Ok(path) => path,
         Err(e) => throw_str(&format!(
             "Error calculating path to multiroom distance map origin: {}",

--- a/src/wrappers/multiroomDistanceMap.ts
+++ b/src/wrappers/multiroomDistanceMap.ts
@@ -4,7 +4,9 @@ import {
   js_path_to_multiroom_distance_map_origin,
   MultiroomDistanceMap,
   multiroomFlowField,
-  multiroomMonoFlowField
+  multiroomMonoFlowField,
+  PathPreferenceGonality,
+  PathPreferenceTurns
 } from '../wasm/screeps_clockwork';
 import { ClockworkMultiroomFlowField } from './multiroomFlowField';
 import { ClockworkMultiroomMonoFlowField } from './multiroomMonoFlowField';
@@ -56,7 +58,7 @@ export class ClockworkMultiroomDistanceMap {
    * Path to the origin from a given position.
    */
   pathToOrigin(start: RoomPosition): ClockworkPath {
-    return new ClockworkPath(js_path_to_multiroom_distance_map_origin(start.__packedPos, this._map));
+    return new ClockworkPath(js_path_to_multiroom_distance_map_origin(start.__packedPos, this._map, PathPreferenceGonality.None, PathPreferenceTurns.None));
   }
 
   /**


### PR DESCRIPTION
This PR is a work in progress. I am seeking feedback before proceeding further.

I have added two new parameters to `path_to_multiroom_distance_map_origin` to make it prefer diagonal or orthogonal directions of travel, or to prefer traveling in straight lines vs turning as often as possible (zigzag).

My immediate use case for a diagonal preference is to make roads that are optimal for placing extensions alongside. My more general use case for zigzag preference is to decrease the distance to arbitrary other room positions when it can be done at no cost.

I would expect to do the same for the other two path modules if this PR is welcome. I haven't written any tests, and am a bit unclear on the preferred way to test the rust functions and the modified js bindings.